### PR TITLE
RedisC process RuntimeConfig can be configured through RedisD

### DIFF
--- a/src/main/java/de/flapdoodle/embed/redis/AbstractRedisProcess.java
+++ b/src/main/java/de/flapdoodle/embed/redis/AbstractRedisProcess.java
@@ -43,6 +43,8 @@ public abstract class AbstractRedisProcess<T extends AbstractRedisConfig, E exte
 
 	boolean stopped = false;
 
+	protected IRuntimeConfig redisCRuntimeConfig;
+
 	public AbstractRedisProcess(Distribution distribution, T config,
 			IRuntimeConfig runtimeConfig, E executable)
 			throws IOException {
@@ -92,10 +94,19 @@ public abstract class AbstractRedisProcess<T extends AbstractRedisConfig, E exte
 
 	protected final boolean sendStopToRedisInstance() {
 		try {
-			boolean result = RedisC.sendShutdown(getConfig().version(),
-					getConfig().net().getServerAddress(), getConfig()
-							.net().getPort(), getConfig()
-							.isNested());
+			boolean result;
+			if (redisCRuntimeConfig == null) {
+				result = RedisC.sendShutdown(getConfig().version(),
+						getConfig().net().getServerAddress(),
+						getConfig().net().getPort(), getConfig()
+								.isNested());
+			} else {
+				result = RedisC.sendShutdown(getConfig().version(),
+						getConfig().net().getServerAddress(),
+						getConfig().net().getPort(), getConfig()
+								.isNested(),
+						redisCRuntimeConfig);
+			}
 			return result;
 		} catch (UnknownHostException e) {
 			logger.log(Level.SEVERE, "sendStop", e);

--- a/src/main/java/de/flapdoodle/embed/redis/RedisDProcess.java
+++ b/src/main/java/de/flapdoodle/embed/redis/RedisDProcess.java
@@ -61,6 +61,10 @@ public class RedisDProcess extends
 
 	}
 
+    public void setRedisCRuntimeConfig(IRuntimeConfig redisCRuntimeConfig) {
+        this.redisCRuntimeConfig = redisCRuntimeConfig;
+    }
+
 	@Override
 	protected void onBeforeProcess(IRuntimeConfig runtimeConfig)
 			throws IOException {

--- a/src/main/java/de/flapdoodle/embed/redis/runtime/RedisC.java
+++ b/src/main/java/de/flapdoodle/embed/redis/runtime/RedisC.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.distribution.IVersion;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.redis.RedisCliExecutable;
@@ -60,6 +61,20 @@ public class RedisC {
 
 	public static boolean sendShutdown(IVersion redisVersion,
 			InetAddress hostname, int port, boolean isNested) {
+		return sendShutdown(redisVersion, hostname, port, isNested,
+				RedisCliStarter.getDefaultInstance());
+	}
+
+	public static boolean sendShutdown(IVersion redisVersion,
+			InetAddress hostname, int port, boolean isNested,
+			IRuntimeConfig runtimeConfig) {
+		return sendShutdown(redisVersion, hostname, port, isNested,
+				RedisCliStarter.getInstance(runtimeConfig));
+	}
+
+	private static boolean sendShutdown(IVersion redisVersion,
+			InetAddress hostname, int port, boolean isNested,
+			RedisCliStarter runtime) {
 		// ensure that we don't get into a stackoverflow when starting the
 		// artifact fails entirely
 		if (isNested) {
@@ -80,8 +95,6 @@ public class RedisC {
 		}
 
 		try {
-			RedisCliStarter runtime = RedisCliStarter
-					.getDefaultInstance();
 			RedisCliConfig redisCliConfig = new RedisCliConfig(
 					redisVersion, new Net(port), new Timeout(
 							WAITING_TIME_SHUTDOWN_IN_MS), true);
@@ -99,4 +112,5 @@ public class RedisC {
 			return false;
 		}
 	}
+
 }


### PR DESCRIPTION
Change allows it to configure the RedisC runtime config. Before redisC, which is used to shutdown a RedisD, always used the defaultGenerated IRuntimeConfig with UUIDNaming. Now one can configure how to name RedisC
