### PR TITLE
Create server.properties

### DIFF
--- a/server.properties
+++ b/server.properties
@@ -1,0 +1,1 @@
+redis.download.url=http://heli0s.darktech.org/redis/


### PR DESCRIPTION
With this server.properties it's possible to properly build redis as redis doesn't offer any binaries itself.
