### PR TITLE
Add Redis 2.8 support

### DIFF
--- a/src/main/java/de/flapdoodle/embed/redis/RedisDProcess.java
+++ b/src/main/java/de/flapdoodle/embed/redis/RedisDProcess.java
@@ -61,9 +61,9 @@ public class RedisDProcess extends
 
 	}
 
-    public void setRedisCRuntimeConfig(IRuntimeConfig redisCRuntimeConfig) {
-        this.redisCRuntimeConfig = redisCRuntimeConfig;
-    }
+	public void setRedisCRuntimeConfig(IRuntimeConfig redisCRuntimeConfig) {
+		this.redisCRuntimeConfig = redisCRuntimeConfig;
+	}
 
 	@Override
 	protected void onBeforeProcess(IRuntimeConfig runtimeConfig)
@@ -86,11 +86,9 @@ public class RedisDProcess extends
 		// db file
 		File tmpDbFile;
 		if (config.getStorage().getDatabaseFile() != null) {
-			tmpDbFile = new File(dbDir, config.getStorage()
-					.getDatabaseFile());
+			tmpDbFile = new File(config.getStorage().getDatabaseFile());
 		} else {
-			tmpDbFile = new File(PropertyOrPlatformTempDir
-					.defaultInstance().asFile(), "dump.rdb");
+			tmpDbFile = new File("dump.rdb");
 			dbFileIsTemp = true;
 		}
 		this.dbFile = tmpDbFile;

--- a/src/main/java/de/flapdoodle/embed/redis/distribution/Version.java
+++ b/src/main/java/de/flapdoodle/embed/redis/distribution/Version.java
@@ -28,19 +28,14 @@ import de.flapdoodle.embed.process.distribution.IVersion;
 public enum Version implements IVersion {
 
 	/**
-	 * new production release
+	 * old 2.6 release release
 	 */
-	V2_4_18("2.4.18_1"),
+	V2_6_14("2.6.14_5"),
 
 	/**
-	 * new developement releases
+	 * new 2.8 release
 	 */
-	@Deprecated
-	V2_6_10("2.6.10"),
-	/**
-	 * newest developement release
-	 */
-	V2_6_14("2.6.14_5"), ;
+	V2_8_3("2.8.3_1"), ;
 
 	private final String specificVersion;
 
@@ -60,15 +55,16 @@ public enum Version implements IVersion {
 
 	public static enum Main implements IVersion {
 		/**
-		 * current production release
+		 * latest production release
 		 */
-		V2_4(V2_4_18),
+		V2_8(V2_8_3),
+
 		/**
-		 * development release
+		 * legacy production release
 		 */
 		V2_6(V2_6_14),
 
-		PRODUCTION(V2_4), DEVELOPMENT(V2_6), ;
+		PRODUCTION(V2_6), DEVELOPMENT(V2_8), ;
 
 		private final IVersion _latest;
 

--- a/src/main/java/de/flapdoodle/embed/redis/runtime/RedisD.java
+++ b/src/main/java/de/flapdoodle/embed/redis/runtime/RedisD.java
@@ -64,8 +64,7 @@ public class RedisD {
 				// daemonized, redis does not give any output..
 				// "--daemonize", "yes",//
 				"--pidfile", pidFile.getAbsolutePath(),//
-				"--dbfilename", dbFile.getAbsolutePath()//
-				));
+				"--dbfilename", dbFile.getName()));
 
 		return ret;
 	}

--- a/src/test/java/de/flapdoodle/embed/redis/RedisExampleAllVersionsTest.java
+++ b/src/test/java/de/flapdoodle/embed/redis/RedisExampleAllVersionsTest.java
@@ -20,8 +20,6 @@
  */
 package de.flapdoodle.embed.redis;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -32,10 +30,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import redis.clients.jedis.Jedis;
 import de.flapdoodle.embed.process.distribution.IVersion;
 import de.flapdoodle.embed.redis.config.RedisDConfig;
 import de.flapdoodle.embed.redis.distribution.Version;
+import redis.clients.jedis.Jedis;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test whether a race condition occurs between setup and tear down of setting
@@ -43,7 +43,7 @@ import de.flapdoodle.embed.redis.distribution.Version;
  * <p/>
  * This test will run a long time based on the download process for all redis
  * versions.
- * 
+ *
  * @author m.joehren
  */
 @RunWith(value = Parameterized.class)
@@ -58,9 +58,9 @@ public class RedisExampleAllVersionsTest {
 			// print out a PID and allow using --port argument. 2.4
 			// versions
 			// don't.
-			if (!version.equals(Version.Main.V2_4)) {
-				result.add(new Object[] { version });
-			}
+			// if (!version.equals(Version.Main.V2_4)) {
+			result.add(new Object[] { version });
+			// }
 		}
 		return result;
 	}

--- a/src/test/java/de/flapdoodle/embed/redis/RedisRuntimeTest.java
+++ b/src/test/java/de/flapdoodle/embed/redis/RedisRuntimeTest.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-import redis.clients.jedis.Jedis;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.distribution.BitSize;
 import de.flapdoodle.embed.process.distribution.Distribution;
@@ -35,6 +33,8 @@ import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.redis.config.RedisDConfig;
 import de.flapdoodle.embed.redis.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.redis.distribution.Version;
+import junit.framework.TestCase;
+import redis.clients.jedis.Jedis;
 
 // CHECKSTYLE:OFF
 public class RedisRuntimeTest extends TestCase {
@@ -80,7 +80,7 @@ public class RedisRuntimeTest extends TestCase {
 		// there is no osx 32bit version for v2.2.1 and above
 		String currentVersion = version.asInDownloadPath();
 		if ((platform == Platform.OS_X) && (bitsize == BitSize.B32)) {
-			if (currentVersion.equals(Version.V2_6_10.asInDownloadPath()))
+			if (currentVersion.equals(Version.V2_8_3.asInDownloadPath()))
 				return true;
 			if (currentVersion.equals(Version.V2_6_14.asInDownloadPath()))
 				return true;

--- a/src/test/java/de/flapdoodle/embed/redis/_TestPaths.java
+++ b/src/test/java/de/flapdoodle/embed/redis/_TestPaths.java
@@ -20,9 +20,6 @@
  */
 package de.flapdoodle.embed.redis;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,6 +28,9 @@ import de.flapdoodle.embed.process.distribution.BitSize;
 import de.flapdoodle.embed.process.distribution.Distribution;
 import de.flapdoodle.embed.process.distribution.Platform;
 import de.flapdoodle.embed.redis.distribution.Version;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class _TestPaths {
 
@@ -44,15 +44,14 @@ public class _TestPaths {
 	@Test
 	public void testDistributionPathsLinux() {
 		// v 2.4.18
-		checkPath(new Distribution(Version.V2_4_18, Platform.Linux,
+		checkPath(new Distribution(Version.V2_8_3, Platform.Linux,
 				BitSize.B64),
-				"/2.4.18_1/redis-dist-2.4.18_1-linux.tar.gz");
-		checkPath(new Distribution(Version.V2_4_18, Platform.Windows,
-				BitSize.B32),
-				"/2.4.18_1/redis-dist-2.4.18_1-windows.zip");
-		checkPath(new Distribution(Version.V2_4_18, Platform.OS_X,
+				"/2.8.3_1/redis-dist-2.8.3_1-linux.tar.gz");
+		checkPath(new Distribution(Version.V2_8_3, Platform.Windows,
+				BitSize.B32), "/2.8.3_1/redis-dist-2.8.3_1-windows.zip");
+		checkPath(new Distribution(Version.V2_8_3, Platform.OS_X,
 				BitSize.B64),
-				"/2.4.18_1/redis-dist-2.4.18_1-macos.tar.gz");
+				"/2.8.3_1/redis-dist-2.8.3_1-macos.tar.gz");
 		// v 2.6.14
 		checkPath(new Distribution(Version.V2_6_14, Platform.Linux,
 				BitSize.B64),
@@ -69,7 +68,7 @@ public class _TestPaths {
 	@Test(expected = IllegalArgumentException.class)
 	@Ignore
 	public void testDistributionPathsOSX() {
-		checkPath(new Distribution(Version.V2_6_10, Platform.OS_X,
+		checkPath(new Distribution(Version.V2_6_14, Platform.OS_X,
 				BitSize.B32), " ");
 	}
 

--- a/src/test/java/de/flapdoodle/embed/redis/examples/TestExampleReadMeCode.java
+++ b/src/test/java/de/flapdoodle/embed/redis/examples/TestExampleReadMeCode.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import junit.framework.TestCase;
-import redis.clients.jedis.Jedis;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.distribution.Distribution;
@@ -59,6 +57,8 @@ import de.flapdoodle.embed.redis.config.RedisDConfig;
 import de.flapdoodle.embed.redis.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.redis.distribution.Version;
 import de.flapdoodle.embed.redis.tests.RedisDForTestsFactory;
+import junit.framework.TestCase;
+import redis.clients.jedis.Jedis;
 
 public class TestExampleReadMeCode extends TestCase {
 
@@ -388,7 +388,7 @@ public class TestExampleReadMeCode extends TestCase {
 	// ### Main Versions
 	public void testMainVersions() throws UnknownHostException, IOException {
 		// ->
-		IVersion version = Version.V2_4_18;
+		IVersion version = Version.V2_6_14;
 		// uses latest supported 2.2.x Version
 		version = Version.Main.V2_6;
 		// uses latest supported production version


### PR DESCRIPTION
Added support for redis 2.8, removing in the same turn 2.4 from the version stack. Redis 2.8 enforces that dbfilename param only contains a filename not a path, so changed that only the filename is set.
